### PR TITLE
fix: return publicUrl from createFile and use it in services

### DIFF
--- a/src/infra/storage/index.ts
+++ b/src/infra/storage/index.ts
@@ -23,5 +23,8 @@ export const createFile = async ({
       reason: error.message,
     })
   }
-  return data
+
+  const { data: urlData } = supabase.storage.from(bucket).getPublicUrl(filePath)
+
+  return { ...data, publicUrl: urlData.publicUrl }
 }

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -54,7 +54,7 @@ export const audioService = {
 
     return {
       data: {
-        audioUrl: uploaded.fullPath,
+        audioUrl: uploaded.publicUrl,
         durationSeconds,
         format,
       },

--- a/src/services/image.ts
+++ b/src/services/image.ts
@@ -60,7 +60,7 @@ export const imageService = {
 
       return {
         data: {
-          imageUrl: uploaded.fullPath,
+          imageUrl: uploaded.publicUrl,
           width,
           height,
           altText: `Generated image for prompt: ${prompt}`,


### PR DESCRIPTION
Supabase upload returns fullPath (a storage path), not a URL. Call getPublicUrl() after upload and expose publicUrl so that audioUrl and imageUrl satisfy z.url() schema validation.

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio and image uploads to return publicly accessible URLs instead of internal file paths, ensuring uploaded content is properly accessible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->