### PR TITLE
fix: correct bucket name from 'images' to 'image' in createFile

### DIFF
--- a/src/services/image.ts
+++ b/src/services/image.ts
@@ -53,7 +53,7 @@ export const imageService = {
       })
 
       const uploaded = await createFile({
-        bucket: 'images',
+        bucket: 'image',
         filePath: `${fileName}.webp`,
         file,
       })


### PR DESCRIPTION
Fixes the bucket name used in `createFile` for image uploads.

- Corrects `'images'` → `'image'` to match the actual Supabase bucket name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected image storage configuration to ensure generated images are reliably saved to the proper location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->