### PR TITLE
fix(metrics): persist nullable token counts

### DIFF
--- a/src/infra/supabase/metrics.ts
+++ b/src/infra/supabase/metrics.ts
@@ -1,7 +1,28 @@
+import { env } from '@/env'
 import { supabase } from '@/infra/supabase/client'
 
 import type { Metrics } from '@/core/metrics/types'
 import { updateModelLatencyStats } from '@/infra/supabase/model-latency-stats'
+
+const serializeSupabaseError = (error: unknown) => {
+  if (!error || typeof error !== 'object') {
+    return error
+  }
+
+  const supabaseError = error as {
+    message?: string
+    code?: string
+    details?: string
+    hint?: string
+  }
+
+  return {
+    message: supabaseError.message,
+    code: supabaseError.code,
+    details: supabaseError.details,
+    hint: supabaseError.hint,
+  }
+}
 
 export const saveMetrics = async (metrics: Metrics) => {
   const { error } = await supabase.from('metrics').insert({
@@ -9,9 +30,9 @@ export const saveMetrics = async (metrics: Metrics) => {
     model_id: metrics.modelId,
     type: metrics.type,
     reason: metrics.reason,
-    input_tokens: metrics.inputTokens,
-    output_tokens: metrics.outputTokens,
-    total_tokens: metrics.totalTokens,
+    input_tokens: metrics.inputTokens ?? 0,
+    output_tokens: metrics.outputTokens ?? 0,
+    total_tokens: metrics.totalTokens ?? 0,
     latency: metrics.latency,
     total_cost: metrics.totalCost,
     is_cost_estimated: metrics.isCostEstimated,
@@ -24,7 +45,10 @@ export const saveMetrics = async (metrics: Metrics) => {
   })
 
   if (error) {
-    console.error('Failed to persist metrics:', error.message)
+    console.error('Failed to persist metrics:', {
+      table: 'metrics',
+      error: serializeSupabaseError(error),
+    })
     return
   }
 


### PR DESCRIPTION
## Summary
- Persist metrics even when providers do not return token usage
- Use zero defaults for nullable token fields to satisfy the Supabase schema
- Keep full Supabase error details in logs for easier debugging

## Why
Some image/audio providers return no usage data, which caused inserts to fail because `input_tokens` was `NOT NULL` in the metrics table.

## Validation
- TypeScript checks pass for the touched files
- The working tree is clean on the feature branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in metric data collection by ensuring all token usage values are properly recorded.
  * Enhanced error reporting to provide better diagnostics when metric collection encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->